### PR TITLE
Fix dtool import in _plugin_depc.py

### DIFF
--- a/_plugin_depc.py
+++ b/_plugin_depc.py
@@ -3,7 +3,7 @@ from ibeis.control import controller_inject  # NOQA
 import numpy as np
 import utool as ut
 import vtool as vt
-import dtool
+from ibeis import dtool
 import ibeis
 
 


### PR DESCRIPTION
dtool was a separate package but has been moved to ibeis, so need to fix
the imports from `import dtool` to `from ibeis import dtool`.